### PR TITLE
added multipid request parser as 'input <hexstring>'

### DIFF
--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -1,6 +1,6 @@
 #! /usr/bin/env node
 import { Command } from 'commander';
-import { getPIDInfo, parseOBDResponse } from '../src/index';
+import { getPIDInfo,parseOBDResponse, parseOBDMultiResponse } from '../src/index';
 
 const program = new Command();
 
@@ -18,6 +18,15 @@ program
   .action((hexString) => {
     const parsedResponse = parseOBDResponse(hexString);
     console.log(JSON.stringify(parsedResponse, null, 4));
+  });
+program
+  .command('input <hexString>')
+  .description('Parse an OBD multiresponse')
+  .action((hexString) => {
+    const parsedResponse = parseOBDMultiResponse(hexString);
+    
+    console.log(JSON.stringify(parsedResponse, null, 4));
+    
   });
 
 program.parse(process.argv);

--- a/src/obdInfo.ts
+++ b/src/obdInfo.ts
@@ -35,6 +35,7 @@ function convertPIDSupported(
 ) {
   const hexstring = byteA + byteB + byteC + byteD;
   const pidHex = hexstring.split('');
+  console.log(pidHex);
   const pidStatus: boolean[] = [];
   pidHex.forEach(function (hex) {
     const hexPerm = Hex2Bin(hex).split('');
@@ -42,7 +43,7 @@ function convertPIDSupported(
       pidStatus.push(perm === '1' ? true : false);
     });
   });
-
+  
   return pidStatus;
 }
 


### PR DESCRIPTION
Ho notato solo un problema riguardo ai pidSupp0,1 etc... che richiamano nel campo convertToUseful la funzione convertPIDSupported. In pratica se uso da terminale parse "41 00 98 3B A0 10" mi restituisce tutto correttamente mentre, quando  richiamo la funzione parse dalla funzione che ho creato, usando la stessa sintassi di sopra, mi restituisce campo value con valore undefined e quindi lo omette proprio nella stampa. Non sono riuscito a trovare l'errore sinceramente ma ho lasciato perdere visto che gli altri pid vengono stampati correttamente(ho provato la richiesta multipid che dovremmo fare in app con i pid rpm,speed,accelerator e fuel rate ed erano tutti corretti).